### PR TITLE
feat: remove reset()

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/lib/event-loop-spinner.ts
+++ b/lib/event-loop-spinner.ts
@@ -9,14 +9,10 @@ export class EventLoopSpinner {
     return Date.now() - this.afterLastSpin > this.thresholdMs;
   }
 
-  public reset(): void {
-    this.afterLastSpin = Date.now();
-  }
-
   public async spin(): Promise<void> {
     return new Promise((resolve) =>
       setImmediate(() => {
-        this.reset();
+        this.afterLastSpin = Date.now();
         resolve();
       }),
     );

--- a/package.json
+++ b/package.json
@@ -16,16 +16,16 @@
     "tslib": "^1.10.0"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.22",
+    "@types/jest": "^25.2.3",
     "@types/node": "^10.17.4",
     "@typescript-eslint/eslint-plugin": "^2.6.1",
     "@typescript-eslint/parser": "^2.6.1",
     "eslint": "^6.6.0",
     "eslint-config-prettier": "^6.5.0",
     "eslint-plugin-jest": "^23.0.3",
-    "jest": "^24.9.0",
+    "jest": "^26.0.1",
     "prettier": "^1.18.2",
-    "ts-jest": "^24.1.0",
+    "ts-jest": "^26.1.0",
     "typescript": "^3.7.2"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "eslint-config-prettier": "^6.5.0",
     "eslint-plugin-jest": "^23.0.3",
     "jest": "^26.0.1",
-    "prettier": "^1.18.2",
+    "prettier": "^2.0.5",
     "ts-jest": "^26.1.0",
     "typescript": "^3.7.2"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
     "outDir": "./dist",
-    "target": "es2015",
+    "target": "es2017",
     "lib": [
-      "es6"
+      "es2017"
     ],
     "module": "commonjs",
     "declaration": true,


### PR DESCRIPTION
BREAKING CHANGE: reset() is gone. Just don't use it.

It is not really safe to use reset() ever. This library is
shared between different bits of code. You cannot know if
they might need to yield, even if you didn't.

It's unclear it's even useful in other cases; much of the cost
of using the library is in checking, not actually spinning.

(Alternative: retain reset(), but make it do nothing?)

Also, while we're BREAKING: target node 8, which should get us better code (no `tslib_1.__awaiter`).
