### PR TITLE
fix(ci): migrate to NPM OIDC trusted publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ jobs:
   release:
     <<: *defaults
     docker:
-      - image: node:20
+      - image: cimg/node:24.18
     steps:
       - checkout
       - install_deps
@@ -97,11 +97,12 @@ jobs:
           name: Run build
           command: npm run build
       - run:
-          name: Publish to GitHub
-          command: npx semantic-release@24
+          name: Publish to npm and GitHub
+          command: |
+            export NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
+            npx semantic-release@25.0.5
 
 workflows:
-  version: 2
   test_and_release:
     jobs:
       - prodsec/secrets-scan:
@@ -125,7 +126,9 @@ workflows:
           <<: *filters_branches_ignore_main
       - release:
           name: Release
-          context: nodejs-lib-release
+          context:
+            - nodejs-install
+            - github-release
           requires:
             - Scan repository for secrets
             - Perform security scans for PRs

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
 package-lock.json
 node_modules
 dist/
-.idea/
+
+# IDE
+/.idea/
+/.vscode/
+/.cursor/

--- a/package.json
+++ b/package.json
@@ -29,13 +29,22 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/snyk/eventloop-spinner.git"
+    "url": "https://github.com/snyk/event-loop-spinner.git"
   },
   "author": "snyk.io",
   "types": "dist/index.d.ts",
-  "bugs": {
-    "url": "https://github.com/snyk/eventloop-spinner/issues"
+  "publishConfig": {
+    "access": "public"
   },
-  "homepage": "https://github.com/snyk/eventloop-spinner#readme",
+  "files": [
+    "dist"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "bugs": {
+    "url": "https://github.com/snyk/event-loop-spinner/issues"
+  },
+  "homepage": "https://github.com/snyk/event-loop-spinner#readme",
   "license": "Apache-2.0"
 }


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/dep-graph/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

### What this does

Set up NPM OIDC Trusted Publishing for the package


### Notes for the reviewer

- This package is still used by Snyk products. The repo and the npm package are both public and they will remain this way. 
- Trusted Publishing from CircleCI has been configured. 
- The release group was granted Write access to the repo.


### More information
- [Jira ticket CMPA-552](https://snyksec.atlassian.net/browse/CMPA-552)
